### PR TITLE
Update win-os-firewall rule any-any created (firewall).yaml

### DIFF
--- a/windows-firewall/win-os-firewall rule any-any created (firewall).yaml
+++ b/windows-firewall/win-os-firewall rule any-any created (firewall).yaml
@@ -17,8 +17,8 @@ detection:
       - 2004  # new rule created
       - 2005  # existing rule modified
     Action: 3 # allow
-    LocalPorts: *
-    RemotePorts: *
+    LocalPorts: '*'
+    RemotePorts: '*'
   condition: selection
 falsepositives:
 - Firewall rule debugging

--- a/windows-firewall/win-os-firewall rule any-any created (firewall).yaml
+++ b/windows-firewall/win-os-firewall rule any-any created (firewall).yaml
@@ -12,14 +12,21 @@ logsource:
   product: windows
   service: firewall
 detection:
-  selection:
+  selection_basic:
     EventID:
       - 2004  # new rule created
       - 2005  # existing rule modified
     Action: 3 # allow
+
+  selection_any_port:
     LocalPorts: '*'
     RemotePorts: '*'
-  condition: selection
+
+  selection_any_address:
+    LocalAddresses: '*' 
+    RemoteAddresses: '*'
+
+  condition: selection_basic and (selection_any_port or selection_any_address)
 falsepositives:
 - Firewall rule debugging
 level: high


### PR DESCRIPTION
Without quotes, sigma refuses to convert the rule. As it is not escaped it will accept any field values.
Any issue has been created related to the logic of the rule.