### PR TITLE
Update win-os-service permissions modified (service).yaml

### DIFF
--- a/windows-services/win-os-service permissions modified (service).yaml
+++ b/windows-services/win-os-service permissions modified (service).yaml
@@ -18,29 +18,26 @@ logsource:
   product: windows
   category: process_creation
 detection:
-  selection_event:
-    EventID: 4688
-
   selection_sdset: # full command (native commmand): "sc sdset XblGameSave "D:(A;;CCLCSWRPWPDTLOCRRC;;;SY)"
-    NewProcessName|endswith: \sc.exe
+    NewProcessName|endswith: '\sc.exe'
     CommandLine|contains|all:
-      - sc
-      - sdset
+      - 'sc'
+      - 'sdset'
 
   selection_subinACL: # full command (3rd party tool): subinacl.exe /service Spooler /grant=contoso\tuser=PTO
     CommandLine|contains|all:
       #- subinacl # not considered as executable name can be changed
-      - service
-      - grant=
+      - 'service'
+      - 'grant='
 
   selection_setACL: # full command (3rd party tool): SetACL.exe -on "schedule" -ot srv -actn list
     CommandLine|contains|all:
       #- setacl # not considered as executable name can be changed
-      - on   # object name
-      - srv  # object type
-      - actn # action
+      - 'on'   # object name
+      - 'srv'  # object type
+      - 'actn' # action
 
-  condition: selection_event and (selection_sdset OR selection_subinACL OR selection_setACL)
+  condition: selection_sdset OR selection_subinACL OR selection_setACL
 falsepositives:
 - administrator reconfiguring service
 level: high


### PR DESCRIPTION
- Removed EventID in favour of `logsource` and `category` field mappings 
- Added quotes to avoid sigma conversion error with potential keywords ('on' line 36 is this case)