### PR TITLE
typo fixed in windows-ntfs symlink command

### DIFF
--- a/windows-ntfs/win-os-NTFS symbolic link creation (command).yaml
+++ b/windows-ntfs/win-os-NTFS symbolic link creation (command).yaml
@@ -12,7 +12,7 @@ logsource:
   category: process_creation
 detection:
   selection:
-    NewProcessName|endswith: '\mklink .exe'
+    NewProcessName|endswith: '\mklink.exe'
     CommandLine|contains:
       - '/h' # hard link
       - '/d' # directory symbolic link


### PR DESCRIPTION
[SIGMA-detection-rules](https://github.com/mdecrevoisier/SIGMA-detection-rules)/[windows-ntfs](https://github.com/mdecrevoisier/SIGMA-detection-rules/tree/main/windows-ntfs)/win-os-NTFS symbolic link creation (command).yaml exe name typo fixed