### PR TITLE
Update win-ad-Kerberos ticket without a trailing $ (CVE-2021-42278).yaml

### DIFF
--- a/windows-active_directory/win-ad-Kerberos ticket without a trailing $ (CVE-2021-42278).yaml
+++ b/windows-active_directory/win-ad-Kerberos ticket without a trailing $ (CVE-2021-42278).yaml
@@ -24,18 +24,18 @@ detection:
     EventID: 4768
     Status: 0x0 # Success
     ServiceSid|endswith: '-502' # Krbtgt account SID
-    TargetUserName.lower() == Computer.split(".")[0].lower() # normal behavior would be that TargetUsername and Computer are different (DC01$ and DC01.domain.lan). Having both matching is suspicious.
+    #TargetUserName.lower() == Computer.split(".")[0].lower() # normal behavior would be that TargetUsername and Computer are different (DC01$ and DC01.domain.lan). Having both matching is suspicious.
 
   selection_tgs:
     EventID: 4769
     Status: 0x0 # Success
     ServiceName|endswith: $
-    TargetUserName.split("@")[0].lower() == Computer.split(".")[0].lower() # normal behavior would be that TargetUsername and Computer are different (DC01$@domain.lan vs DC01.domain.lan). Having both matching is suspicious.
+    #TargetUserName.split("@")[0].lower() == Computer.split(".")[0].lower() # normal behavior would be that TargetUsername and Computer are different (DC01$@domain.lan vs DC01.domain.lan). Having both matching is suspicious.
 
   selection_host:
     TargetUserName|contains: "$"
 
-  condition: (selection_tgt or selection_tgs) AND NOT selection_host
+  condition: (selection_tgt or selection_tgs) and not selection_host
 falsepositives:
 - None
 level: high


### PR DESCRIPTION
commented out a few lines that were causing yaml validation errors and modified the sigma condition statement for proper sigma parsing.