### PR TITLE
Rules Fix: Account Management and Account Logon 

### DIFF
--- a/windows-active_directory/win-ad-DPAPI attribute accessed (DCSync, Mimikatz, RiskySPN).yaml
+++ b/windows-active_directory/win-ad-DPAPI attribute accessed (DCSync, Mimikatz, RiskySPN).yaml
@@ -37,6 +37,7 @@ level: informational
 
 ---
 title: Suspicious Active Directory DPAPI attributes accessed Count
+status: experimental
 correlation:
   type: value_count
   rules:

--- a/windows-active_directory/win-ad-Kerberos  brutforce enumeration with unexisting users.yaml
+++ b/windows-active_directory/win-ad-Kerberos  brutforce enumeration with unexisting users.yaml
@@ -1,11 +1,12 @@
 title: Brutforce enumeration with unexisting users (Kerberos)
+name: bruteforce_non_existing_users_kerberos
 description: Detects scenarios where an attacker attempts to enumerate potential existing users, resulting in failed Kerberos TGT requests with unexisting or invalid accounts.
 references:
-- https://github.com/mdecrevoisier/EVTX-to-MITRE-Attack/tree/master/TA0006-Credential%20Access/T1110.xxx-Brut%20force
-- https://github.com/ropnop/kerbrute
+  - https://github.com/mdecrevoisier/EVTX-to-MITRE-Attack/tree/master/TA0006-Credential%20Access/T1110.xxx-Brut%20force
+  - https://github.com/ropnop/kerbrute
 tags:
-- attack.credential_access
-- attack.t1110
+  - attack.credential_access
+  - attack.t1110
 author: mdecrevoisier
 status: experimental
 logsource:
@@ -16,12 +17,26 @@ detection:
     EventID:
       - 4771
       - 4768
-    Status: '0x6' # KDC_ERR_C_PRINCIPAL_UNKNOWN
+    Status: "0x6" # KDC_ERR_C_PRINCIPAL_UNKNOWN
   filter:
-    - IpAddress: '%domain_controllers_ips%' # reduce amount of false positives
-    - TicketOptions: 0x50800000             # covered by Kerbrute rule
-  condition: selection and not filter | count(TargetUserName) by Computer > 20 # Count how many failed logins with non existing users were reported on the domain controller.
-  timeframe: 30m
+    - IpAddress: "%domain_controllers_ips%" # reduce amount of false positives
+    - TicketOptions: 0x50800000 # covered by Kerbrute rule
+  condition: selection and not filter
 falsepositives:
-- Missconfigured application or identity services
+  - Missconfigured application or identity services
+level: high
+
+---
+title: Brutforce enumeration with unexisting users (Kerberos) Count
+status: experimental
+correlation:
+  type: value_count
+  rules:
+    - bruteforce_non_existing_users_kerberos # Referenced here
+  group-by:
+    - Computer
+  timespan: 30m
+  condition:
+    gte: 20
+    field: TargetUserName # Count how many failed logins with non existing users were reported on the domain controller.
 level: high

--- a/windows-active_directory/win-ad-Kerberos enumeration with existing-unexsting users (Kerbrute).yaml
+++ b/windows-active_directory/win-ad-Kerberos enumeration with existing-unexsting users (Kerbrute).yaml
@@ -1,12 +1,13 @@
 title: Kerberos enumeration with existing/unexisting users (Kerbrute)
+name: kerbrute_enumeration
 description: Detects scenarios where an attacker attempts to enumerate existing or non existing users using "Kerbrute". This use case can also be related to spot vulnearbility "MS14-068".
 references:
-- https://github.com/mdecrevoisier/EVTX-to-MITRE-Attack/tree/master/TA0006-Credential%20Access/T1110.xxx-Brut%20force
-- https://github.com/ropnop/kerbrute
-- https://www.jpcert.or.jp/english/pub/sr/20170612ac-ir_research_en.pdf
+  - https://github.com/mdecrevoisier/EVTX-to-MITRE-Attack/tree/master/TA0006-Credential%20Access/T1110.xxx-Brut%20force
+  - https://github.com/ropnop/kerbrute
+  - https://www.jpcert.or.jp/english/pub/sr/20170612ac-ir_research_en.pdf
 tags:
-- attack.credential_access
-- attack.t1110
+  - attack.credential_access
+  - attack.t1110
 author: mdecrevoisier
 status: experimental
 logsource:
@@ -17,13 +18,27 @@ detection:
     EventID:
       - 4771
       - 4768
-    Status: '0x6' # KDC_ERR_C_PRINCIPAL_UNKNOWN
+    Status: "0x6" # KDC_ERR_C_PRINCIPAL_UNKNOWN
     TicketOptions: 0x50800000
   filter:
-    - IpAddress: '%domain_controllers_ips%'     # reduce amount of false positives
-    - TargetUserName: '%account_allowed_proxy%' # accounts allowed to perform proxiable requests
-  condition: selection and not filter | count(TargetUserName) by Computer > 20 # Count how many failed logins were reported on the domain controller.
-  timeframe: 30m
+    - IpAddress: "%domain_controllers_ips%" # reduce amount of false positives
+    - TargetUserName: "%account_allowed_proxy%" # accounts allowed to perform proxiable requests
+  condition: selection and not filter
 falsepositives:
-- Missconfigured application or identity services
+  - Missconfigured application or identity services
+level: high
+
+---
+title: Kerberos enumeration with existing/unexisting users (Kerbrute) Count
+status: experimental
+correlation:
+  type: value_count
+  rules:
+    - kerbrute_enumeration # Referenced here
+  group-by:
+    - Computer
+  timespan: 30m
+  condition:
+    gte: 20
+    field: TargetUserName # Count how many failed logins were reported on the domain controller.
 level: high

--- a/windows-active_directory/win-ad-SAM domain users & groups massive enumeration.yaml
+++ b/windows-active_directory/win-ad-SAM domain users & groups massive enumeration.yaml
@@ -1,13 +1,13 @@
 title: Massive SAM users/groups enumeration (native)
-description: Detects scenarios where an attacker attempts to enumerate sensitive domain users/groups settings and membership.
-correlation: correlate TargetLogonId from ID 4624 with SubjectLogonId from ID 4661 to identify the source of the enumeration.
+name: SAM_enumeration_user_group
+description: Detects scenarios where an attacker attempts to enumerate sensitive domain users/groups settings and membership. Correlate TargetLogonId from ID 4624 with SubjectLogonId from ID 4661 to identify the source of the enumeration.
 requirements: extended rights auditing enabled (https://www.manageengine.com/products/active-directory-audit/active-directory-auditing-configuration-guide-configure-object-level-auditing-manually.html)
 references:
-- https://github.com/mdecrevoisier/EVTX-to-MITRE-Attack/tree/master/TA0007-Discovery/T1069-Permission%20Groups%20Discovery
-- https://bitvijays.github.io/LFF-IPS-P3-Exploitation.html
+  - https://github.com/mdecrevoisier/EVTX-to-MITRE-Attack/tree/master/TA0007-Discovery/T1069-Permission%20Groups%20Discovery
+  - https://bitvijays.github.io/LFF-IPS-P3-Exploitation.html
 tags:
-- attack.discovery
-- attack.t1069.002
+  - attack.discovery
+  - attack.t1069.002
 author: mdecrevoisier
 status: experimental
 logsource:
@@ -17,7 +17,7 @@ detection: # net group <domain_group> /domain
   selection:
     EventID: 4661
     ProcessName|endswith: '\lsass.exe'
-    ObjectServer: 'Security Account Manager'
+    ObjectServer: "Security Account Manager"
     ObjectName|startswith:
       - S-1-5-32- # refers to builtin domain local groups
       - S-1-5-21- # refers to domain users and groups
@@ -25,13 +25,27 @@ detection: # net group <domain_group> /domain
       - SAM_USER
       - SAM_GROUP
   filter:
-    - SubjectUserName|endswith: '$'
+    - SubjectUserName|endswith: "$"
     - ObjectName|endswith: # already covered in a separated rule for sensitive user & group enumeration
-      - '-500' # local administrator
-      - '-512' # Domain Admins
-      - '-513' # Domain users (less critical)
-  condition: selection and not filter | count(ObjectName) by Computer > 30
-  timeframe: 15m
+        - "-500" # local administrator
+        - "-512" # Domain Admins
+        - "-513" # Domain users (less critical)
+  condition: selection and not filter
 falsepositives:
-- Administrator activity
+  - Administrator activity
+level: informational
+
+---
+title: Massive SAM users/groups enumeration (native)
+status: experimental
+correlation:
+  type: value_count
+  rules:
+    - SAM_enumeration_user_group
+  group-by:
+    - Computer
+  timespan: 15m
+  condition:
+    gte: 30
+    field: ObjectName
 level: high

--- a/windows-active_directory/win-ad-SharpHound host enumeration over Kerberos.yaml
+++ b/windows-active_directory/win-ad-SharpHound host enumeration over Kerberos.yaml
@@ -1,13 +1,14 @@
 title: SharpHound host enumeration over Kerberos
+name: sharphound_enumeration_kerberos
 description: Detect if a source host is requesting multiple Kerberos Service tickets (TGS) for different assets in a short period of time.
 references:
-- https://docs.microsoft.com/en-us/windows/security/threat-protection/auditing/event-4769
-- https://github.com/mdecrevoisier/EVTX-to-MITRE-Attack/tree/master/TA0007-Discovery/T1087-Account%20discovery
-- https://www.splunk.com/en_us/blog/security/sharing-is-not-caring-hunting-for-file-share-discovery.html
+  - https://docs.microsoft.com/en-us/windows/security/threat-protection/auditing/event-4769
+  - https://github.com/mdecrevoisier/EVTX-to-MITRE-Attack/tree/master/TA0007-Discovery/T1087-Account%20discovery
+  - https://www.splunk.com/en_us/blog/security/sharing-is-not-caring-hunting-for-file-share-discovery.html
 tags:
-- attack.discovery
-- attack.t1069.002
-- attack.t1087.002
+  - attack.discovery
+  - attack.t1069.002
+  - attack.t1087.002
 author: mdecrevoisier
 status: experimental
 logsource:
@@ -16,15 +17,29 @@ logsource:
 detection:
   selection:
     EventID: 4769
-    ServiceName|endswith: '$'
+    ServiceName|endswith: "$"
     Status: 0x0
   filter:
     - IpAddress:
-      - '::1'
-      - '%domain_controllers_ip%'
+        - "::1"
+        - "%domain_controllers_ip%"
     - TargetUserName|contains: "$@" # excludes computer accounts
-  condition: selection and not filter | count(ServiceName) by IpAddress > 20
-  timeframe: 5m
+  condition: selection and not filter
 falsepositives:
-- Administrator activity, backup software
+  - Administrator activity, backup software
 level: medium
+
+---
+title: SharpHound host enumeration over Kerberos Count
+status: experimental
+correlation:
+  type: value_count
+  rules:
+    - sharphound_enumeration_kerberos
+  group-by:
+    - ServiceName
+  timespan: 5m
+  condition:
+    gte: 20
+    field: IpAddress
+level: high

--- a/windows-active_directory/win-ad-bruteforce via password reset.yaml
+++ b/windows-active_directory/win-ad-bruteforce via password reset.yaml
@@ -1,11 +1,12 @@
 title: Bruteforce via password reset
-description: Detects if a attacker attempts to reset multiple times a user password to perform a bruteforce attack. 
+name: bruteforce_password_reset
+description: Detects if a attacker attempts to reset multiple times a user password to perform a bruteforce attack.
 references:
-- https://twitter.com/mthcht/status/1705164058343756005?s=08
+  - https://twitter.com/mthcht/status/1705164058343756005?s=08
 tags:
-- attack.credential_access
-- attack.t1110.001 # brutforce: Password Guessing 
-- attack.t1110.003 # brutforce: Password spraying 
+  - attack.credential_access
+  - attack.t1110.001 # brutforce: Password Guessing
+  - attack.t1110.003 # brutforce: Password spraying
 author: mdecrevoisier
 status: experimental
 logsource:
@@ -16,7 +17,22 @@ detection:
     EventID:
       - 4723 # reset of own user's password
       - 4724 # reset of user's password by another user
-  condition: selection | count() by TargetSid, host > 10
+  condition: selection
 falsepositives:
-- ADFS, DirSync 
+  - ADFS, DirSync
+level: informational
+
+---
+title: Bruteforce via password reset Count
+status: experimental
+correlation:
+  type: value_count
+  rules:
+    - bruteforce_password_reset
+  group-by:
+    - TargetSid
+  timespan: 10m
+  condition:
+    gte: 10
+    field: host
 level: high

--- a/windows-active_directory/win-ad-group massive membership changes.yaml
+++ b/windows-active_directory/win-ad-group massive membership changes.yaml
@@ -1,10 +1,11 @@
 title: Massive group membership changes detected
-description: Detects scenarios where an attacker will add a compromised account into different domain groups in order to gain access to all the assets under the control of those concerned groups. 
+name: massive_group_changes
+description: Detects scenarios where an attacker will add a compromised account into different domain groups in order to gain access to all the assets under the control of those concerned groups.
 references:
-- https://github.com/mdecrevoisier/EVTX-to-MITRE-Attack/tree/master/TA0003-Persistence/T1098.xxx-Account%20manipulation
+  - https://github.com/mdecrevoisier/EVTX-to-MITRE-Attack/tree/master/TA0003-Persistence/T1098.xxx-Account%20manipulation
 tags:
-- attack.persistence
-- attack.t1098
+  - attack.persistence
+  - attack.t1098
 author: mdecrevoisier
 status: experimental
 logsource:
@@ -16,8 +17,22 @@ detection:
       - 4728 # security global group member added
       - 4756 # universal group member added
       - 4732 # local and domain local group member added
-  condition: selection | count(TargetSid) by SubjectUserSid > 20 # Count how many different groups had a member added in a short period by the same user
-  timeframe: 15m
+  condition: selection
 falsepositives:
-- Automatic scripts, provisionning accounts
+  - Automatic scripts, provisionning accounts
 level: medium
+
+---
+title: Massive group membership changes detected Count
+status: experimental
+correlation:
+  type: value_count
+  rules:
+    - massive_group_changes # Referenced here
+  group-by:
+    - SubjectUserSid
+  timespan: 15m
+  condition:
+    gte: 20
+    field: TargetSid # Count how many different groups had a member added in a short period by the same user
+level: high

--- a/windows-active_directory/win-ad-kerberoast ticket detected.yaml
+++ b/windows-active_directory/win-ad-kerberoast ticket detected.yaml
@@ -1,27 +1,28 @@
 title: Kerberoast ticket request detected
+name: kerberoast_ticket_request
 description: Detects scenarios where an attacker requests a Kerberoast ticket with low encryption to perform offline brutforce and forge a new ticket to get access to the targeted resource.
 references:
-- https://github.com/mdecrevoisier/EVTX-to-MITRE-Attack/tree/master/TA0006-Credential%20Access/T1558-Steal%20or%20Forge%20Kerberos%20Tickets
-- https://www.trustedsec.com/blog/the-art-of-bypassing-kerberoast-detections-with-orpheus/
-- https://blog.harmj0y.net/redteaming/kerberoasting-revisited/
-- https://blog.harmj0y.net/powershell/kerberoasting-without-mimikatz/
-- https://www.hackingarticles.in/as-rep-roasting/
-- https://adsecurity.org/?p=2293
-- https://adsecurity.org/?p=3458
-- https://blog.stealthbits.com/extracting-service-account-passwords-with-kerberoasting/
-- https://blogs.technet.microsoft.com/motiba/2018/02/23/detecting-kerberoasting-activity-using-azure-security-center/
-- https://github.com/nidem/kerberoast
-- https://github.com/skelsec/kerberoast
-- https://posts.specterops.io/capability-abstraction-fbeaeeb26384
-- https://www.trimarcsecurity.com/single-post/TrimarcResearch/Detecting-Kerberoasting-Activity
-- https://m365internals.com/2021/11/08/kerberoast-with-opsec/
-- https://redcanary.com/blog/marshmallows-and-kerberoasting/
-- https://www.semperis.com/blog/new-attack-paths-as-requested-sts/
-- https://www.trustedsec.com/blog/the-art-of-bypassing-kerberoast-detections-with-orpheus/
-- https://nored0x.github.io/red-teaming/Kerberos-Attacks-Kerbroasting/
+  - https://github.com/mdecrevoisier/EVTX-to-MITRE-Attack/tree/master/TA0006-Credential%20Access/T1558-Steal%20or%20Forge%20Kerberos%20Tickets
+  - https://www.trustedsec.com/blog/the-art-of-bypassing-kerberoast-detections-with-orpheus/
+  - https://blog.harmj0y.net/redteaming/kerberoasting-revisited/
+  - https://blog.harmj0y.net/powershell/kerberoasting-without-mimikatz/
+  - https://www.hackingarticles.in/as-rep-roasting/
+  - https://adsecurity.org/?p=2293
+  - https://adsecurity.org/?p=3458
+  - https://blog.stealthbits.com/extracting-service-account-passwords-with-kerberoasting/
+  - https://blogs.technet.microsoft.com/motiba/2018/02/23/detecting-kerberoasting-activity-using-azure-security-center/
+  - https://github.com/nidem/kerberoast
+  - https://github.com/skelsec/kerberoast
+  - https://posts.specterops.io/capability-abstraction-fbeaeeb26384
+  - https://www.trimarcsecurity.com/single-post/TrimarcResearch/Detecting-Kerberoasting-Activity
+  - https://m365internals.com/2021/11/08/kerberoast-with-opsec/
+  - https://redcanary.com/blog/marshmallows-and-kerberoasting/
+  - https://www.semperis.com/blog/new-attack-paths-as-requested-sts/
+  - https://www.trustedsec.com/blog/the-art-of-bypassing-kerberoast-detections-with-orpheus/
+  - https://nored0x.github.io/red-teaming/Kerberos-Attacks-Kerbroasting/
 tags:
-- attack.credential_access
-- attack.t1558.003
+  - attack.credential_access
+  - attack.t1558.003
 author: mdecrevoisier
 status: experimental
 logsource:
@@ -31,24 +32,38 @@ detection:
   selection:
     EventID: 4769
     #TicketOptions: # depending on the source/tool, the options may change.
-      #- 0x40810000
-      #- 0x40800000
-      #- 0x40810010
-      #- 0x40800010
+    #- 0x40810000
+    #- 0x40800000
+    #- 0x40810010
+    #- 0x40800010
     TicketEncryptionType: 0x17 # RC4-HMAC
     Status: 0x0 # Success
   filter:
-    - ServiceName|endswith: '$'     # Exclude computer account services
-    - ServiceSid: 'S-1-5-21-*-0'    # Exclude domain Service
-    - ServiceSid|endswith: '-502'   # Exclude Krbtgt service
-    - TargetUserName|contains: '$@' # Exclude computer accounts requests
+    - ServiceName|endswith: "$" # Exclude computer account services
+    - ServiceSid: "S-1-5-21-*-0" # Exclude domain Service
+    - ServiceSid|endswith: "-502" # Exclude Krbtgt service
+    - TargetUserName|contains: "$@" # Exclude computer accounts requests
     - IpAddress:
-      - '::1'
-      - '127.0.0.1'
-      - '%domain_controllers_ips%'
+        - "::1"
+        - "127.0.0.1"
+        - "%domain_controllers_ips%"
     #- ServiceName NOT IN TargetUserName (NOT SUPPORTED BY ALL SIEM)
-  condition: selection and not filter | count(ServiceName) by IpAddress > 2
-  timeframe: 30m 
+  condition: selection and not filter
 falsepositives:
-- Applications using RC4 encryption (SAP, Azure AD, legacy applications...)
+  - Applications using RC4 encryption (SAP, Azure AD, legacy applications...)
+level: high
+
+---
+title: Kerberoast ticket request detected Count
+status: experimental
+correlation:
+  type: value_count
+  rules:
+    - kerberoast_ticket_request
+  group-by:
+    - ServiceName
+  timespan: 30m
+  condition:
+    gte: 2
+    field: IpAddress
 level: high

--- a/windows-active_directory/win-ad-user password change with changeNTLM (Mimikatz).yaml
+++ b/windows-active_directory/win-ad-user password change with changeNTLM (Mimikatz).yaml
@@ -1,14 +1,13 @@
 title: User password change using current hash password - ChangeNTLM (Mimikatz)
-description: Detects scenarios where an attacker resets a user account by using the compromised NTLM password hash. The newly clear text password defined by the attacker can be then used in order to login into services like Outlook Web Access (OWA), RDP, SharePoint... As ID 4723 refers to user changing is own password, the SubjectSid and TargetSid should be equal. However in a change initiated by Mimikatz, they will be different.
-correlation: correlate the event ID 4723, 4624 and 5145 using the "SubjectLogonId" field to identify the source of the reset.
+description: Detects scenarios where an attacker resets a user account by using the compromised NTLM password hash. The newly clear text password defined by the attacker can be then used in order to login into services like Outlook Web Access (OWA), RDP, SharePoint... As ID 4723 refers to user changing is own password, the SubjectSid and TargetSid should be equal. However in a change initiated by Mimikatz, they will be different. Correlate the event ID 4723, 4624 and 5145 using the "SubjectLogonId" field to identify the source of the reset.
 references:
-- https://github.com/mdecrevoisier/EVTX-to-MITRE-Attack/tree/master/TA0003-Persistence/T1098.xxx-Account%20manipulation
-- https://stealthbits.com/blog/manipulating-user-passwords-with-mimikatz/
-- https://www.trustedsec.com/blog/azure-account-hijacking-using-mimikatzs-lsadumpsetntlm/
-- https://www.trustedsec.com/blog/manipulating-user-passwords-without-mimikatz/
+  - https://github.com/mdecrevoisier/EVTX-to-MITRE-Attack/tree/master/TA0003-Persistence/T1098.xxx-Account%20manipulation
+  - https://stealthbits.com/blog/manipulating-user-passwords-with-mimikatz/
+  - https://www.trustedsec.com/blog/azure-account-hijacking-using-mimikatzs-lsadumpsetntlm/
+  - https://www.trustedsec.com/blog/manipulating-user-passwords-without-mimikatz/
 tags:
-- attack.persistence
-- attack.t1098
+  - attack.persistence
+  - attack.t1098
 author: mdecrevoisier
 status: experimental
 logsource:
@@ -22,6 +21,6 @@ detection:
     #SubjectUserSid != TargetSid # comparing 2 fields is not possible in SIGMA language
   condition: selection
 falsepositives:
-- Admin changing is own account directly using the Active Directory console and not the GUI (ctrl alt suppr)
-- ADFS, MSOL, DirSync, Azure AD Sync
+  - Admin changing is own account directly using the Active Directory console and not the GUI (ctrl alt suppr)
+  - ADFS, MSOL, DirSync, Azure AD Sync
 level: high

--- a/windows-active_directory/win-ad-user password change with setNTLM (Mimikatz).yaml
+++ b/windows-active_directory/win-ad-user password change with setNTLM (Mimikatz).yaml
@@ -1,14 +1,13 @@
 title: User password change without previous password known - SetNTLM (Mimikatz)
-description: Detects scenarios where an attacker perform a password reset event. This does not require any knowledge of a user’s current password, but it does require to have the "Reset Password" right.
-correlation: correlate the event ID 4724, 4624 and 5145 using the "SubjectLogonId" field to identify the source of the reset.
+description: Detects scenarios where an attacker perform a password reset event. This does not require any knowledge of a user’s current password, but it does require to have the "Reset Password" right. Correlate the event ID 4724, 4624 and 5145 using the "SubjectLogonId" field to identify the source of the reset.
 references:
-- https://github.com/mdecrevoisier/EVTX-to-MITRE-Attack/tree/master/TA0003-Persistence/T1098.xxx-Account%20manipulation
-- https://stealthbits.com/blog/manipulating-user-passwords-with-mimikatz/
-- https://www.trustedsec.com/blog/azure-account-hijacking-using-mimikatzs-lsadumpsetntlm/
-- https://www.trustedsec.com/blog/manipulating-user-passwords-without-mimikatz/
+  - https://github.com/mdecrevoisier/EVTX-to-MITRE-Attack/tree/master/TA0003-Persistence/T1098.xxx-Account%20manipulation
+  - https://stealthbits.com/blog/manipulating-user-passwords-with-mimikatz/
+  - https://www.trustedsec.com/blog/azure-account-hijacking-using-mimikatzs-lsadumpsetntlm/
+  - https://www.trustedsec.com/blog/manipulating-user-passwords-without-mimikatz/
 tags:
-- attack.persistence
-- attack.t1098
+  - attack.persistence
+  - attack.t1098
 author: mdecrevoisier
 status: experimental
 logsource:
@@ -31,10 +30,10 @@ detection:
 
   filter:
     IpAddress:
-      - '127.0.0.1'
-      - '::1'
+      - "127.0.0.1"
+      - "::1"
 
   condition: (selection_reset and selection_share and selection_login) and not filter
 falsepositives:
-- None
+  - None
 level: high

--- a/windows-openssh/win-os-OpenSSH brutforce enumeration with unexisting users.yaml
+++ b/windows-openssh/win-os-OpenSSH brutforce enumeration with unexisting users.yaml
@@ -1,14 +1,15 @@
 title: Brutforce enumeration on Windows OpenSSH server with non existing user
+name: openssh_bruteforce_non_existing_user
 description: Detects scenarios where an attacker attempts to SSH brutforce a Windows OpenSSH server with non existing users.
 remarks: This requires to have previously enabled the builtin OpenSSH server or to have installed the "OpenSSH-Win64" component. IpAddress or Workstation fields may be empty. In case Workstation field is not empty, be aware that it may wrongly report the source host. Also note that SSH logins are reported with logon type 8 (clear text). For reliable source IP information, use the logs from the OpenSSH channel, event ID 4.
 references:
-- https://github.com/mdecrevoisier/EVTX-to-MITRE-Attack/tree/master/TA0006-Credential%20Access/T1110.xxx-Brut%20force
-- https://winaero.com/enable-openssh-server-windows-10/
-- https://docs.microsoft.com/en-us/windows-server/administration/openssh/openssh_install_firstuse
-- https://virtualizationreview.com/articles/2020/05/21/ssh-server-on-windows-10.aspx
+  - https://github.com/mdecrevoisier/EVTX-to-MITRE-Attack/tree/master/TA0006-Credential%20Access/T1110.xxx-Brut%20force
+  - https://winaero.com/enable-openssh-server-windows-10/
+  - https://docs.microsoft.com/en-us/windows-server/administration/openssh/openssh_install_firstuse
+  - https://virtualizationreview.com/articles/2020/05/21/ssh-server-on-windows-10.aspx
 tags:
-- attack.credential_access
-- attack.t1110
+  - attack.credential_access
+  - attack.t1110
 author: mdecrevoisier
 status: experimental
 logsource:
@@ -17,10 +18,24 @@ logsource:
 detection:
   selection:
     EventID: 4625
-    SubStatus: '0xc0000064'  # Non existing user
+    SubStatus: "0xc0000064" # Non existing user
     ProcessName|endswith: '\sshd.exe' # Can be "C:\Program Files\OpenSSH-Win64\sshd.exe" or "C:\Windows\system32\OpenSSH\sshd.exe"
-  condition: selection | count(TargetUserName) by Computer > 20 # Count how many non existing users were reported on the host.
-  timeframe: 30m
+  condition: selection
 falsepositives:
-- None
+  - None
+level: high
+
+---
+title: Brutforce enumeration on Windows OpenSSH server with non existing user Count
+status: experimental
+correlation:
+  type: value_count
+  rules:
+    - openssh_bruteforce_non_existing_user # Referenced here
+  group-by:
+    - Computer
+  timespan: 30m
+  condition:
+    gte: 20
+    field: TargetUserName
 level: high

--- a/windows-os/win-os-brutforce attempt with valid user (OpenSSH).yaml
+++ b/windows-os/win-os-brutforce attempt with valid user (OpenSSH).yaml
@@ -1,14 +1,15 @@
 title: Brutforce on Windows OpenSSH server with valid users
+name: bruteforce_openssh_vaild_users
 description: Detects scenarios where an attacker attempts to SSH brutforce a Windows OpenSSH server with a valid user.
 remarks: This requires to have previously enabled the builtin OpenSSH server or to have installed the "OpenSSH-Win64" component. IpAddress or Workstation fields may be empty. In case Workstation field is not empty, be aware that it may wrongly report the source host. Also note that SSH logins are reported with logon type 8 (clear text). For reliable source IP information, use the logs from the OpenSSH channel, event ID 4.
 references:
-- https://github.com/mdecrevoisier/EVTX-to-MITRE-Attack/tree/master/TA0006-Credential%20Access/T1110.xxx-Brut%20force
-- https://winaero.com/enable-openssh-server-windows-10/
-- https://docs.microsoft.com/en-us/windows-server/administration/openssh/openssh_install_firstuse
-- https://virtualizationreview.com/articles/2020/05/21/ssh-server-on-windows-10.aspx
+  - https://github.com/mdecrevoisier/EVTX-to-MITRE-Attack/tree/master/TA0006-Credential%20Access/T1110.xxx-Brut%20force
+  - https://winaero.com/enable-openssh-server-windows-10/
+  - https://docs.microsoft.com/en-us/windows-server/administration/openssh/openssh_install_firstuse
+  - https://virtualizationreview.com/articles/2020/05/21/ssh-server-on-windows-10.aspx
 tags:
-- attack.credential_access
-- attack.t1110
+  - attack.credential_access
+  - attack.t1110
 author: mdecrevoisier
 status: experimental
 logsource:
@@ -17,12 +18,26 @@ logsource:
 detection:
   selection:
     EventID: 4625
-    SubStatus: '0xc000006A' # invalid password | Failure code can be defined in "Status" or "Substatus" fields. Usually, if Substatus == 0x0, refers to Status.
-    ProcessName|endswith:   # Can be "C:\Program Files\OpenSSH-Win64\sshd.exe" or "C:\Windows\system32\OpenSSH\sshd.exe"
+    SubStatus: "0xc000006A" # invalid password | Failure code can be defined in "Status" or "Substatus" fields. Usually, if Substatus == 0x0, refers to Status.
+    ProcessName|endswith: # Can be "C:\Program Files\OpenSSH-Win64\sshd.exe" or "C:\Windows\system32\OpenSSH\sshd.exe"
       - '\sshd.exe'
       - '\ssh.exe'
-  condition: selection | count(EventRecordID) by Computer > 20 # Count how many failed logins were reported on the host.
-  timeframe: 30m
+  condition: selection
 falsepositives:
-- None
+  - None
+level: high
+
+---
+title: Brutforce on Windows OpenSSH server with valid users Count
+status: experimental
+correlation:
+  type: value_count
+  rules:
+    - bruteforce_openssh_vaild_users # Referenced here
+  group-by:
+    - Computer
+  timespan: 30m
+  condition:
+    gte: 20
+    field: EventRecordID
 level: high

--- a/windows-os/win-os-brutforce enumeration with unexisting users.yaml
+++ b/windows-os/win-os-brutforce enumeration with unexisting users.yaml
@@ -1,11 +1,12 @@
 title: Brutforce enumeration with non existing users (login)
+name: login_non_existing_user
 description: Detects scenarios where an attacker attempts to enumerate potential existing users, resulting in failed logins with unexisting or invalid accounts.
 references:
-- https://github.com/mdecrevoisier/EVTX-to-MITRE-Attack/tree/master/TA0006-Credential%20Access/T1110.xxx-Brut%20force
-- https://docs.microsoft.com/en-us/windows/security/threat-protection/auditing/event-4625
+  - https://github.com/mdecrevoisier/EVTX-to-MITRE-Attack/tree/master/TA0006-Credential%20Access/T1110.xxx-Brut%20force
+  - https://docs.microsoft.com/en-us/windows/security/threat-protection/auditing/event-4625
 tags:
-- attack.credential_access
-- attack.t1110
+  - attack.credential_access
+  - attack.t1110
 author: mdecrevoisier
 status: experimental
 logsource:
@@ -14,11 +15,25 @@ logsource:
 detection:
   selection:
     EventID: 4625
-    SubStatus: '0xc0000064' # user not found | Failure code can be defined in "Status" or "Substatus" fields. Usually, if Substatus == 0x0, refers to Status.
+    SubStatus: "0xc0000064" # user not found | Failure code can be defined in "Status" or "Substatus" fields. Usually, if Substatus == 0x0, refers to Status.
   filter:
-    IpAddress: '%domain_controllers_ips%' # reduce amount of false positives
-  condition: selection and not filter | count(TargetUserName) by Computer > 20 # Count how many failed logins with non existing users were reported on the host.
-  timeframe: 30m
+    IpAddress: "%domain_controllers_ips%" # reduce amount of false positives
+  condition: selection and not filter
 falsepositives:
-- Missconfigured application
+  - Missconfigured application
+level: high
+
+---
+title: Brutforce enumeration with non existing users (login) Count
+status: experimental
+correlation:
+  type: value_count
+  rules:
+    - login_non_existing_user # Referenced here
+  group-by:
+    - Computer
+  timespan: 30m
+  condition:
+    gte: 20
+    field: TargetUserName
 level: high

--- a/windows-os/win-os-brutforce with denied access due to account restrictions.yaml
+++ b/windows-os/win-os-brutforce with denied access due to account restrictions.yaml
@@ -1,11 +1,12 @@
 title: Brutforce with denied access due to account restrictions policies
+name: bruteforce_denied_account_restriction_policies
 description: Detects scenarios where an attacker attemps to use a comprimised account but failed to login due to account restrictions policies (permissions, time restrictions, workstation, logon type, ...)
 references:
-- https://github.com/mdecrevoisier/EVTX-to-MITRE-Attack/tree/master/TA0001-Initial%20access/T1078-Valid%20accounts
-- https://docs.microsoft.com/en-us/windows/security/threat-protection/auditing/event-4625
+  - https://github.com/mdecrevoisier/EVTX-to-MITRE-Attack/tree/master/TA0001-Initial%20access/T1078-Valid%20accounts
+  - https://docs.microsoft.com/en-us/windows/security/threat-protection/auditing/event-4625
 tags:
-- attack.privilege_escalation
-- attack.t1078
+  - attack.privilege_escalation
+  - attack.t1078
 author: mdecrevoisier
 status: experimental
 logsource:
@@ -15,14 +16,28 @@ detection:
   selection:
     EventID: 4625
     Status: # Failure code can be defined in "Status" or "Substatus" fields. Usually, if Substatus == 0x0, refers to Status.
-      - '0xc0000022' # STATUS_ACCESS_DENIED - A process has requested access to an object, but has not been granted those access rights.
-      - '0xC0000413' # STATUS_AUTHENTICATION_FIREWALL_FAILED - Account is not allowed to authenticate to the machine
-      - '0xC000006E' # STATUS_ACCOUNT_RESTRICTION - Indicates a referenced user name and authentication information are valid, but some user account restriction has prevented successful authentication (such as time-of-day restrictions).
-      - '0xC000006F' # STATUS_INVALID_LOGON_HOURS - The user account has time restrictions and cannot be logged onto at this time.
-      - '0xC0000070' # STATUS_INVALID_WORKSTATION - The user account is restricted so that it cannot be used to log on from the source workstation.
-      - '0xC000015B' # STATUS_LOGON_TYPE_NOT_GRANTED - A user has requested a type of logon (for example, interactive or network) that has not been granted. An administrator has control over who can logon interactively and through the network.
-  condition: selection | count(EventRecordID) by Computer > 10
-  timeframe: 30m
+      - "0xc0000022" # STATUS_ACCESS_DENIED - A process has requested access to an object, but has not been granted those access rights.
+      - "0xC0000413" # STATUS_AUTHENTICATION_FIREWALL_FAILED - Account is not allowed to authenticate to the machine
+      - "0xC000006E" # STATUS_ACCOUNT_RESTRICTION - Indicates a referenced user name and authentication information are valid, but some user account restriction has prevented successful authentication (such as time-of-day restrictions).
+      - "0xC000006F" # STATUS_INVALID_LOGON_HOURS - The user account has time restrictions and cannot be logged onto at this time.
+      - "0xC0000070" # STATUS_INVALID_WORKSTATION - The user account is restricted so that it cannot be used to log on from the source workstation.
+      - "0xC000015B" # STATUS_LOGON_TYPE_NOT_GRANTED - A user has requested a type of logon (for example, interactive or network) that has not been granted. An administrator has control over who can logon interactively and through the network.
+  condition: selection
 falsepositives:
-- missconfigured accounts
+  - missconfigured accounts
 level: medium
+
+---
+title: Brutforce with denied access due to account restrictions policies Count
+status: experimental
+correlation:
+  type: value_count
+  rules:
+    - bruteforce_denied_account_restriction_policies # Referenced here
+  group-by:
+    - Computer
+  timespan: 30m
+  condition:
+    gte: 10
+    field: EventRecordID
+level: high

--- a/windows-rdp/win-rdp-discovery performed on multiple hosts.yaml
+++ b/windows-rdp/win-rdp-discovery performed on multiple hosts.yaml
@@ -1,27 +1,27 @@
 title: RDP discovery performed on multiple hosts
-description: Detects scenarios where an attacker attempts to discover active RDP services via tools like Hydra. Note that this event doesn't provide any information about login outcome (success or failure) as well as user information.
-correlation: for further correlation, ID 4624/4625 (logon type 3, 7 or 10) as well as ID 1149 should be used.
+name: rdp_discovery_multiple_host
+description: Detects scenarios where an attacker attempts to discover active RDP services via tools like Hydra. Note that this event doesn't provide any information about login outcome (success or failure) as well as user information. For further correlation, ID 4624/4625 (logon type 3, 7 or 10) as well as ID 1149 should be used.
 references:
-- https://github.com/mdecrevoisier/EVTX-to-MITRE-Attack/tree/master/TA0007-Discovery/T1046-Network%20Service%20Scanning
-- https://github.com/mehranexpert/Crazy-RDP
-- https://github.com/3gstudent/SharpRDPCheck
-- https://ponderthebits.com/2018/02/windows-rdp-related-event-logs-identification-tracking-and-investigation/
-- https://purerds.org/remote-desktop-security/auditing-remote-desktop-services-logon-failures-1/
-- http://woshub.com/rdp-connection-logs-forensics-windows/
-- https://jpcertcc.github.io/ToolAnalysisResultSheet/details/mstsc.htm
-- https://github.com/AndrewRathbun/DFIRMindMaps/tree/main/OSArtifacts/Windows/RDP_Authentication_Artifacts
-- https://github.com/TonyPhipps/SIEM/blob/master/Notable-Event-IDs.md#microsoft-windows-remotedesktopservices-rdpcoretsoperational
-- https://dfironthemountain.wordpress.com/2019/02/15/rdp-event-log-dfir/
-- https://nullsec.us/windows-event-id-1029-hashes/
-- https://www.13cubed.com/downloads/rdp_flowchart.pdf
-- https://nullsec.us/windows-rdp-related-event-logs-the-client-side-of-the-story/
+  - https://github.com/mdecrevoisier/EVTX-to-MITRE-Attack/tree/master/TA0007-Discovery/T1046-Network%20Service%20Scanning
+  - https://github.com/mehranexpert/Crazy-RDP
+  - https://github.com/3gstudent/SharpRDPCheck
+  - https://ponderthebits.com/2018/02/windows-rdp-related-event-logs-identification-tracking-and-investigation/
+  - https://purerds.org/remote-desktop-security/auditing-remote-desktop-services-logon-failures-1/
+  - http://woshub.com/rdp-connection-logs-forensics-windows/
+  - https://jpcertcc.github.io/ToolAnalysisResultSheet/details/mstsc.htm
+  - https://github.com/AndrewRathbun/DFIRMindMaps/tree/main/OSArtifacts/Windows/RDP_Authentication_Artifacts
+  - https://github.com/TonyPhipps/SIEM/blob/master/Notable-Event-IDs.md#microsoft-windows-remotedesktopservices-rdpcoretsoperational
+  - https://dfironthemountain.wordpress.com/2019/02/15/rdp-event-log-dfir/
+  - https://nullsec.us/windows-event-id-1029-hashes/
+  - https://www.13cubed.com/downloads/rdp_flowchart.pdf
+  - https://nullsec.us/windows-rdp-related-event-logs-the-client-side-of-the-story/
 tags:
-- attack.discovery
-- attack.t1046 # network service scanning
-- attack.credential_access
-- attack.t1110 # brutforce
-- attack.lateral_movement
-- attack.t1021.001 # remote services: RDP
+  - attack.discovery
+  - attack.t1046 # network service scanning
+  - attack.credential_access
+  - attack.t1110 # brutforce
+  - attack.lateral_movement
+  - attack.t1021.001 # remote services: RDP
 author: mdecrevoisier
 status: experimental
 logsource:
@@ -33,12 +33,26 @@ detection:
     Channel: Microsoft-Windows-RemoteDesktopServices-RdpCoreTS/Operational
   filter:
     IpAddress: # In ID 131, IP address is provided in "ClientIP.split(":")[0]
-      - '%vulnerability_scanners%'
-      - '%admin_jump_hosts%'
-      - '127.0.0.1'
-      - '::1'
-  condition: selection and not filter | count(Computer) by IpAddress > 20 # Count of many computer are reporting connection attemps from a single source IP
-  timeframe: 5m
+      - "%vulnerability_scanners%"
+      - "%admin_jump_hosts%"
+      - "127.0.0.1"
+      - "::1"
+  condition: selection and not filter
 falsepositives:
-- VAS scanners, administrator jump host
+  - VAS scanners, administrator jump host
+level: high
+
+---
+title: RDP discovery performed on multiple hosts Count
+status: experimental
+correlation:
+  type: value_count
+  rules:
+    - rdp_discovery_multiple_host # Referenced here
+  group-by:
+    - IpAddress
+  timespan: 5m
+  condition:
+    gte: 20
+    field: Computer # Count of many computer are reporting connection attemps from a single source IP
 level: high

--- a/windows-rdp/win-rdp-reconnaissance with valid credentials performed to multiple hosts.yaml
+++ b/windows-rdp/win-rdp-reconnaissance with valid credentials performed to multiple hosts.yaml
@@ -1,25 +1,25 @@
 title: RDP reconnaissance with valid credentials performed on multiple hosts
-description: Detects scenarios where an attacker attempts to brutforce RDP services with compromised credentials via tools like Hydra. Note that this event will be reported only with valid user and password credentials, and it may be reported only when RDP session is fully opened (so not during reconnaisance phase) if NLA is disabled.
-correlation: for further correlation, ID 4624/4625 (logon type 3, 7 or 10) should be used.
+name: rdp_reconnaissance_valid_cred
+description: Detects scenarios where an attacker attempts to brutforce RDP services with compromised credentials via tools like Hydra. Note that this event will be reported only with valid user and password credentials, and it may be reported only when RDP session is fully opened (so not during reconnaisance phase) if NLA is disabled. For further correlation, ID 4624/4625 (logon type 3, 7 or 10) should be used.
 references:
-- https://github.com/mdecrevoisier/EVTX-to-MITRE-Attack/tree/master/TA0001-Initial%20access/T1078-Valid%20accounts
-- https://github.com/mehranexpert/Crazy-RDP
-- https://github.com/3gstudent/SharpRDPCheck
-- https://ponderthebits.com/2018/02/windows-rdp-related-event-logs-identification-tracking-and-investigation/
-- https://purerds.org/remote-desktop-security/auditing-remote-desktop-services-logon-failures-1/
-- http://woshub.com/rdp-connection-logs-forensics-windows/
-- https://jpcertcc.github.io/ToolAnalysisResultSheet/details/mstsc.htm
-- https://github.com/AndrewRathbun/DFIRMindMaps/tree/main/OSArtifacts/Windows/RDP_Authentication_Artifacts
-- https://github.com/TonyPhipps/SIEM/blob/master/Notable-Event-IDs.md#microsoft-windows-remotedesktopservices-rdpcoretsoperational
-- https://dfironthemountain.wordpress.com/2019/02/15/rdp-event-log-dfir/
-- https://nullsec.us/windows-event-id-1029-hashes/
-- https://www.13cubed.com/downloads/rdp_flowchart.pdf
-- https://nullsec.us/windows-rdp-related-event-logs-the-client-side-of-the-story/
+  - https://github.com/mdecrevoisier/EVTX-to-MITRE-Attack/tree/master/TA0001-Initial%20access/T1078-Valid%20accounts
+  - https://github.com/mehranexpert/Crazy-RDP
+  - https://github.com/3gstudent/SharpRDPCheck
+  - https://ponderthebits.com/2018/02/windows-rdp-related-event-logs-identification-tracking-and-investigation/
+  - https://purerds.org/remote-desktop-security/auditing-remote-desktop-services-logon-failures-1/
+  - http://woshub.com/rdp-connection-logs-forensics-windows/
+  - https://jpcertcc.github.io/ToolAnalysisResultSheet/details/mstsc.htm
+  - https://github.com/AndrewRathbun/DFIRMindMaps/tree/main/OSArtifacts/Windows/RDP_Authentication_Artifacts
+  - https://github.com/TonyPhipps/SIEM/blob/master/Notable-Event-IDs.md#microsoft-windows-remotedesktopservices-rdpcoretsoperational
+  - https://dfironthemountain.wordpress.com/2019/02/15/rdp-event-log-dfir/
+  - https://nullsec.us/windows-event-id-1029-hashes/
+  - https://www.13cubed.com/downloads/rdp_flowchart.pdf
+  - https://nullsec.us/windows-rdp-related-event-logs-the-client-side-of-the-story/
 tags:
-- attack.initial_access
-- attack.t1078 # valid account
-- attack.lateral_movement
-- attack.t1021.001 # remote services: RDP
+  - attack.initial_access
+  - attack.t1078 # valid account
+  - attack.lateral_movement
+  - attack.t1021.001 # remote services: RDP
 author: mdecrevoisier
 status: experimental
 logsource:
@@ -31,13 +31,27 @@ detection:
     Channel: Microsoft-Windows-TerminalServices-RemoteConnectionManager/Operational
   filter:
     IpAddress: # In ID 1149, IP address is provided in "EventXML.Param3"
-      - '%vulnerability_scanners%'
-      - '%admin_jump_hosts%'
-      - '127.0.0.1'
-      - '::1'
+      - "%vulnerability_scanners%"
+      - "%admin_jump_hosts%"
+      - "127.0.0.1"
+      - "::1"
 
-  condition: selection and not filter | count(Computer) by IpAddress > 20 # Count of many computer are reporting connection attemps from a single source IP
-  timeframe: 5m
+  condition: selection and not filter
 falsepositives:
-- VAS scanners, administrator jump host
+  - VAS scanners, administrator jump host
+level: high
+
+---
+title: RDP reconnaissance with valid credentials performed on multiple hosts Count
+status: experimental
+correlation:
+  type: value_count
+  rules:
+    - rdp_reconnaissance_valid_cred # Referenced here
+  group-by:
+    - IpAddress
+  timespan: 5m
+  condition:
+    gte: 20
+    field: Computer
 level: high


### PR DESCRIPTION
Changes in rules for the below Event IDs:
1. 4679
2. 4662
3. 4661
4. 4723
5. 4724

The error arises because the Sigma rule uses the pipe syntax (|) in the condition, which has been deprecated and is not supported by the new pySigma tool. To resolve this, we need to adapt the rule to avoid the deprecated syntax and align it with current Sigma specifications.

I tried to replace the deprecated syntax with a correlation rule.

Kindly review it and let me know if anything goes wrong.